### PR TITLE
Make API provider configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,13 @@ For when you want to preload files into conversation context:
    cd deepseek-engineer
    ```
 
-2. **Set up environment**:
-   ```bash
-   # Create .env file
-   echo "DEEPSEEK_API_KEY=your_api_key_here" > .env
+2. **Configure API credentials**:
+   Open `deepseek-eng.py` and set the `API_KEY`, `BASE_URL`, and `MODEL`
+   constants at the top of the file. Example:
+   ```python
+   API_KEY = "my api key"
+   BASE_URL = "https://llm.chutes.ai/v1/chat/completions"
+   MODEL = "deepseek-ai/DeepSeek-R1-0528"
    ```
 
 3. **Install dependencies** (choose one method):
@@ -224,10 +227,9 @@ Based on my analysis of your project, here's a comprehensive refactoring plan...
 
 ### **Common Issues**
 
-**API Key Not Found**
+**API Key Not Set**
 ```bash
-# Make sure .env file exists with your API key
-echo "DEEPSEEK_API_KEY=your_key_here" > .env
+# Edit deepseek-eng.py and set the API_KEY constant with your key
 ```
 
 **Import Errors**

--- a/deepseek-eng.py
+++ b/deepseek-eng.py
@@ -8,7 +8,6 @@ from textwrap import dedent
 from typing import List, Dict, Any, Optional
 from openai import OpenAI
 from pydantic import BaseModel
-from dotenv import load_dotenv
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
@@ -28,13 +27,16 @@ prompt_session = PromptSession(
 )
 
 # --------------------------------------------------------------------------------
-# 1. Configure OpenAI client and load environment variables
-# --------------------------------------------------------------------------------
-load_dotenv()  # Load environment variables from .env file
+# 1. Configure OpenAI client
+
+API_KEY = "your_api_key_here"
+BASE_URL = "https://api.deepseek.com"
+MODEL = "deepseek-reasoner"
+
 client = OpenAI(
-    api_key=os.getenv("DEEPSEEK_API_KEY"),
-    base_url="https://api.deepseek.com"
-)  # Configure for DeepSeek API
+    api_key=API_KEY,
+    base_url=BASE_URL
+)  # Configure OpenAI-compatible API endpoint
 
 # --------------------------------------------------------------------------------
 # 2. Define our schema using Pydantic for type safety
@@ -586,7 +588,7 @@ def stream_openai_response(user_message: str):
     # Remove the old file guessing logic since we'll use function calls
     try:
         stream = client.chat.completions.create(
-            model="deepseek-reasoner",
+            model=MODEL,
             messages=conversation_history,
             tools=tools,
             max_completion_tokens=64000,
@@ -695,7 +697,7 @@ def stream_openai_response(user_message: str):
                 console.print("\n[bold bright_blue]🔄 Processing results...[/bold bright_blue]")
                 
                 follow_up_stream = client.chat.completions.create(
-                    model="deepseek-reasoner",
+                    model=MODEL,
                     messages=conversation_history,
                     tools=tools,
                     max_completion_tokens=64000,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,5 @@ dependencies = [
     "openai>=1.58.1",
     "prompt-toolkit>=3.0.50",
     "pydantic>=2.10.4",
-    "python-dotenv>=1.0.1",
     "rich>=13.9.4",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 openai
 pydantic
-python-dotenv
 rich
-prompt_toolkit 
+prompt_toolkit

--- a/uv.lock
+++ b/uv.lock
@@ -50,7 +50,6 @@ dependencies = [
     { name = "openai" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
-    { name = "python-dotenv" },
     { name = "rich" },
 ]
 
@@ -59,7 +58,6 @@ requires-dist = [
     { name = "openai", specifier = ">=1.58.1" },
     { name = "prompt-toolkit", specifier = ">=3.0.50" },
     { name = "pydantic", specifier = ">=2.10.4" },
-    { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "rich", specifier = ">=13.9.4" },
 ]
 
@@ -294,10 +292,8 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dotenv"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
 ]


### PR DESCRIPTION
## Summary
- remove dotenv dependency and use constants for provider configuration
- reference the new constants in the code
- document how to set API_KEY, BASE_URL and MODEL

## Testing
- `pip install -r requirements.txt`
- `python3 -m py_compile deepseek-eng.py`


------
https://chatgpt.com/codex/tasks/task_e_68418d280f188324b53bbc62d21379e1